### PR TITLE
Readd Bill of Materials Syncing

### DIFF
--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/Ae2EmiPlugin.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/Ae2EmiPlugin.java
@@ -5,6 +5,7 @@ import appeng.core.AEConfig;
 import appeng.core.definitions.AEBlocks;
 import appeng.core.definitions.AEItems;
 import appeng.core.definitions.AEParts;
+import appeng.menu.me.common.MEStorageMenu;
 import appeng.menu.me.items.CraftingTermMenu;
 import appeng.menu.me.items.PatternEncodingTermMenu;
 import appeng.recipes.entropy.EntropyRecipe;
@@ -16,6 +17,7 @@ import dev.emi.emi.api.EmiRegistry;
 import dev.emi.emi.api.recipe.VanillaEmiRecipeCategories;
 import dev.emi.emi.api.stack.EmiStack;
 import org.blocovermelho.ae2emicrafting.client.handler.Ae2CraftingHandler;
+import org.blocovermelho.ae2emicrafting.client.handler.Ae2MeTerminalHandler;
 import org.blocovermelho.ae2emicrafting.client.handler.Ae2PatternTerminalHandler;
 import org.blocovermelho.ae2emicrafting.client.handler.generic.Ae2BaseScreenExclusionZones;
 import org.blocovermelho.ae2emicrafting.client.handler.generic.Ae2BaseDragHandler;
@@ -40,6 +42,9 @@ public class Ae2EmiPlugin implements EmiPlugin {
 
         registry.addRecipeHandler(CraftingTermMenu.TYPE, new Ae2CraftingHandler<>(CraftingTermMenu.class));
         registry.addRecipeHandler(PatternEncodingTermMenu.TYPE, new Ae2PatternTerminalHandler<>(PatternEncodingTermMenu.class));
+        // Workaround: Seeing Items from ME Terminal on Synthetic Favourites without using the GenericStackProvider.
+        // Reasoning: For whatever reason that is broken on fluids, even though it shouldn't.
+        registry.addRecipeHandler(MEStorageMenu.TYPE, new Ae2MeTerminalHandler<>(MEStorageMenu.class));
 
         registry.addCategory(Ae2CategoryHolder.WORLD_INTERACTION);
         Ae2CategoryHolder.addAll(registry, TransformRecipe.TYPE, Ae2TransformRecipe::new);

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/handler/Ae2MeTerminalHandler.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/handler/Ae2MeTerminalHandler.java
@@ -1,0 +1,20 @@
+package org.blocovermelho.ae2emicrafting.client.handler;
+
+import appeng.menu.me.common.MEStorageMenu;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.text.Text;
+import org.blocovermelho.ae2emicrafting.client.handler.generic.Ae2BaseRecipeHandler;
+import org.blocovermelho.ae2emicrafting.client.helper.rendering.Result;
+import org.jetbrains.annotations.Nullable;
+
+public class Ae2MeTerminalHandler<T extends MEStorageMenu> extends Ae2BaseRecipeHandler<T> {
+    public Ae2MeTerminalHandler(Class<T> containerClass) {
+        super(containerClass);
+    }
+
+    @Override
+    protected Result transferRecipe(T menu, @Nullable Recipe<?> recipe, EmiRecipe emiRecipe, boolean doTransfer) {
+        return Result.createFailed(Text.translatable("ae2-emi-crafting.error.crafting.storage_terminal"));
+    }
+}

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/handler/generic/Ae2BaseRecipeHandler.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/handler/generic/Ae2BaseRecipeHandler.java
@@ -1,10 +1,14 @@
 package org.blocovermelho.ae2emicrafting.client.handler.generic;
 
 import appeng.menu.AEBaseMenu;
+import appeng.menu.SlotSemantics;
+import appeng.menu.me.common.MEStorageMenu;
+import appeng.menu.me.items.CraftingTermMenu;
 import dev.emi.emi.api.recipe.EmiPlayerInventory;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.recipe.handler.EmiCraftContext;
 import dev.emi.emi.api.recipe.handler.EmiRecipeHandler;
+import dev.emi.emi.api.stack.EmiStack;
 import dev.emi.emi.api.widget.Widget;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
@@ -12,6 +16,8 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.client.gui.tooltip.TooltipComponent;
 import net.minecraft.recipe.Recipe;
 import net.minecraft.text.Text;
+import net.minecraft.util.collection.DefaultedList;
+import org.blocovermelho.ae2emicrafting.client.helper.InventoryUtils;
 import org.blocovermelho.ae2emicrafting.client.helper.rendering.Result;
 import org.jetbrains.annotations.Nullable;
 
@@ -28,7 +34,28 @@ public abstract class Ae2BaseRecipeHandler<T extends AEBaseMenu> implements EmiR
 
     @Override
     public EmiPlayerInventory getInventory(HandledScreen<T> screen) {
-        return new EmiPlayerInventory(List.of());
+        T handler = screen.getScreenHandler();
+        if (handler instanceof MEStorageMenu menu) {
+            DefaultedList<EmiStack> allStack = DefaultedList.of();
+
+            List<EmiStack> meSystem = InventoryUtils.getExistingStacks(menu);
+            allStack.addAll(meSystem);
+
+            List<EmiStack> hotbar = InventoryUtils.getStacks(screen, SlotSemantics.PLAYER_HOTBAR);
+            allStack.addAll(hotbar);
+
+            List<EmiStack> inventory = InventoryUtils.getStacks(screen, SlotSemantics.PLAYER_INVENTORY);
+            allStack.addAll(inventory);
+
+            if (menu instanceof CraftingTermMenu) {
+                List<EmiStack> craft = InventoryUtils.getStacks(screen, SlotSemantics.CRAFTING_GRID);
+                allStack.addAll(craft);
+            }
+
+            return new EmiPlayerInventory(allStack);
+        } else {
+            return EmiPlayerInventory.of(handler.getPlayer());
+        }
     }
 
     protected abstract Result transferRecipe(T menu,

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/InventoryUtils.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/InventoryUtils.java
@@ -1,0 +1,40 @@
+package org.blocovermelho.ae2emicrafting.client.helper;
+
+import appeng.api.stacks.GenericStack;
+import appeng.menu.AEBaseMenu;
+import appeng.menu.SlotSemantic;
+import appeng.menu.me.common.GridInventoryEntry;
+import appeng.menu.me.common.MEStorageMenu;
+import dev.emi.emi.api.stack.EmiStack;
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.screen.slot.Slot;
+import org.blocovermelho.ae2emicrafting.client.helper.mapper.EmiStackHelper;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+public class InventoryUtils {
+    public static <T extends AEBaseMenu> List<EmiStack> getStacks(HandledScreen<T> menu, SlotSemantic semantic) {
+        return menu.getScreenHandler().getSlots(semantic).stream()
+                .map(Slot::getStack)
+                .map(EmiStack::of)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    public static <T extends MEStorageMenu> List<EmiStack> getExistingStacks(T menu) {
+        Set<GridInventoryEntry> allEntries = menu.getClientRepo().getAllEntries();
+        if (allEntries == null) {
+            return List.of();
+        }
+
+        return allEntries.stream()
+                .filter(it -> it.getWhat() != null)
+                .filter(it -> it.getStoredAmount() > 0 || it.getRequestableAmount() > 0)
+                .map(it -> new GenericStack(it.getWhat(), Math.max(it.getStoredAmount(), it.getRequestableAmount())))
+                .map(EmiStackHelper::toEmiStack)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/mapper/EmiItemStackConverter.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/mapper/EmiItemStackConverter.java
@@ -1,6 +1,5 @@
 package org.blocovermelho.ae2emicrafting.client.helper.mapper;
 
-import appeng.api.stacks.AEFluidKey;
 import appeng.api.stacks.AEItemKey;
 import appeng.api.stacks.GenericStack;
 import dev.emi.emi.api.stack.EmiStack;
@@ -17,8 +16,8 @@ public class EmiItemStackConverter implements EmiStackConverter {
 
     @Override
     public @Nullable EmiStack toEmiStack(GenericStack stack) {
-        if (stack.what() instanceof AEFluidKey fluidKey) {
-            return EmiStack.of(fluidKey.getFluid(), fluidKey.copyTag(), stack.amount());
+        if (stack.what() instanceof AEItemKey itemKey) {
+            return EmiStack.of(itemKey.getItem(), stack.amount());
         }
 
         return null;

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/mapper/EmiStackHelper.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/mapper/EmiStackHelper.java
@@ -4,6 +4,7 @@ import appeng.api.stacks.GenericStack;
 import dev.emi.emi.api.recipe.EmiRecipe;
 import dev.emi.emi.api.stack.EmiIngredient;
 import dev.emi.emi.api.stack.EmiStack;
+import org.blocovermelho.ae2emicrafting.client.AE2EmiCraftingPlugin;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -22,6 +23,14 @@ public final class EmiStackHelper {
             }
         }
 
+        if(emiStack != null) {
+            AE2EmiCraftingPlugin.LOGGER.error("================ Missing Converter Error =================");
+            AE2EmiCraftingPlugin.LOGGER.error("Couldn't find a  GenericStack converter for EmiStack: " + emiStack.getItemStack());
+            AE2EmiCraftingPlugin.LOGGER.error("Please report this to the developers");
+            AE2EmiCraftingPlugin.LOGGER.error("https://github.com/blocovermelho/ae2-emi-crafting");
+            AE2EmiCraftingPlugin.LOGGER.error("================ Missing Converter Error =================");
+        }
+
         return null;
     }
 
@@ -32,6 +41,15 @@ public final class EmiStackHelper {
             if (emiStack != null) {
                 return emiStack;
             }
+        }
+
+        if(stack.what() != null) {
+            AE2EmiCraftingPlugin.LOGGER.error("================ Missing Converter Error =================");
+            AE2EmiCraftingPlugin.LOGGER.error(":k AeKey is " + stack.what().getClass());
+            AE2EmiCraftingPlugin.LOGGER.error("Couldn't find a EmiStack converter for AeKey: " + stack.what().toTagGeneric().asString());
+            AE2EmiCraftingPlugin.LOGGER.error("Please report this to the developers");
+            AE2EmiCraftingPlugin.LOGGER.error("https://github.com/blocovermelho/ae2-emi-crafting");
+            AE2EmiCraftingPlugin.LOGGER.error("================ Missing Converter Error =================");
         }
 
         return null;

--- a/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/rendering/Result.java
+++ b/src/main/java/org/blocovermelho/ae2emicrafting/client/helper/rendering/Result.java
@@ -158,6 +158,11 @@ public sealed abstract class Result {
                            DrawContext guiGraphics) {
             renderMissingAndCraftableSlotOverlays(widgets, guiGraphics, missingSlots, Set.of());
         }
+
+        @Override
+        public List<Text> getTooltip(EmiRecipe emiRecipe, EmiCraftContext<?> context) {
+            return List.of(getMessage());
+        }
     }
 
     public static NotApplicable createNotApplicable() {

--- a/src/main/resources/assets/ae2-emi-crafting/lang/en_us.json
+++ b/src/main/resources/assets/ae2-emi-crafting/lang/en_us.json
@@ -4,5 +4,6 @@
   "ae2-emi-crafting.category_attunement": "P2P Tunnel Attunement",
   "ae2-emi-crafting.category_transform": "In-World Transformation",
   "ae2-emi-crafting.category_charger": "Charger",
-  "ae2-emi-crafting.category_entropy_manipulator": "Entropy Manipulator"
+  "ae2-emi-crafting.category_entropy_manipulator": "Entropy Manipulator",
+  "ae2-emi-crafting.error.crafting.storage_terminal": "Cannot craft using a ME Storage Terminal"
 }


### PR DESCRIPTION
I've made this at the start of the mod, and this is **not** an official™ Applied Energistics 2 EMI addon feature at all.

BoM Syncing and the "Craftables" thing are all features that came from inside my head since I found EMI a charming item list mod that did things a bit different then everything before so I made sure to try to use all of its features.

They're both back now.

Now its time to brace myself for the people coming from this unofficial EMI plugin that I made cause there wasn't any and "We wont support EMI cause EMI has different API, if they want an official plugin plz be more like REI" was the mentality of AE devs back then, going to the official AE plugin and seeing that its different in this regard.

Honestly I should make a screen with toggles so people can opt-in for this sort of convenience feature.